### PR TITLE
Migrate to managed identity and PowerShell from AzureRM to Az

### DIFF
--- a/Metadata.json
+++ b/Metadata.json
@@ -12,9 +12,9 @@
     "ReleaseDate": "2019-1-17T00:00:00",
     "RunbookKind": 6,
     "RunbookKindString": "PowerShell Workflow",
-    "Summary": "This script suspends/Resume the PowerBI\u00a0 Embedded Capacity in Azure by a given PBE resource name.Pre-Requisites\u00a0Install\u00a0AzureRM.PowerBIEmbedded\u00a0moduleYou have to create your automation account as Run As Account feature, sine this script uses AzureRunAsConnection for authentic",
+    "Summary": "This script suspends/Resume the PowerBI\u00a0 Embedded Capacity in Azure by a given PBE resource name.Pre-Requisites\u00a0Install\u00a0Az.PowerBIEmbedded\u00a0moduleYou have to create your automation account as Run As Account feature, sine this script uses Connect-AzAccount for authentic",
     "Title": "Suspend_Resume_PBI-Embedded by Single resource",
-    "UpdatedDate": "2019-1-17T00:00:00",
+    "UpdatedDate": "2023-1-25T00:00:00",
     "Url": "https://github.com/azureautomation/suspend_resume_pbiembedded-by-single-resource",
     "UserTags": "Powershell, PowerShell Workflow, PowerBI"
 }

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ This script suspends/Resume the PowerBI  Embedded Capacity in Azure by a given 
 **Pre-Requisites **
 
 
-  *  Install [AzureRM.PowerBIEmbedded](https://docs.microsoft.com/en-us/powershell/module/azurerm.powerbiembedded/?view=azurermps-6.13.0) module
+  *  Install [Az.PowerBIEmbedded](https://learn.microsoft.com/en-us/powershell/module/az.powerbiembedded) module
 
-  *  You have to create your automation account as Run As Account feature, sine this script uses AzureRunAsConnection for authentication against Azure.
+  *  You have to create your automation account as System-assigned managed identity feature, since this script uses Connect-AzAccount for authentication against Azure.
 
 
  

--- a/Suspend_Resume_PBI-Embedded.ps1
+++ b/Suspend_Resume_PBI-Embedded.ps1
@@ -14,29 +14,19 @@
     )  
     $connectionName = "AzureRunAsConnection" 
  
-    try 
-    { 
-        # Get the connection "AzureRunAsConnection " 
-        $servicePrincipalConnection=Get-AutomationConnection -Name $connectionName          
- 
-        "Logging in to Azure..." 
-        Add-AzureRmAccount -ServicePrincipal -TenantId $servicePrincipalConnection.TenantId -ApplicationId $servicePrincipalConnection.ApplicationId -CertificateThumbprint $servicePrincipalConnection.CertificateThumbprint  
-              
-    } 
-    catch { 
-        if (!$servicePrincipalConnection) 
-        { 
-            $ErrorMessage = "Connection $connectionName not found." 
-            throw $ErrorMessage 
-        } else{ 
-            Write-Error -Message $_.Exception 
-            throw $_.Exception 
-        } 
+    try
+    {
+        "Logging in to Azure..."
+        Connect-AzAccount -Identity
     }
-
+    catch {
+        Write-Error -Message $_.Exception
+        throw $_.Exception
+    }
+    
     #checking if the PowerBI Embedded Capacity Exisit 
 
-    $IsPBEmbExisit=Test-AzureRmPowerBIEmbeddedCapacity -Name $PowerBIEmbeddedName
+    $IsPBEmbExisit=Test-AzPowerBIEmbeddedCapacity -Name $PowerBIEmbeddedName
 
     if($IsPBEmbExisit -eq $true)
     {
@@ -47,7 +37,7 @@
                 #Suspending the Service 
 
                 "Suspending $PowerBIEmbeddedName started"
-                $SuspendOperation = Suspend-AzureRmPowerBIEmbeddedCapacity -Name $PowerBIEmbeddedName -ResourceGroupName $AzureResourceGroup -PassThru
+                $SuspendOperation = Suspend-AzPowerBIEmbeddedCapacity -Name $PowerBIEmbeddedName -ResourceGroupName $AzureResourceGroup -PassThru
                 "$PowerBIEmbeddedName is Suspended Successfully"
             }
             catch
@@ -64,7 +54,7 @@
                 #Resuming the Service 
 
                 "Resuming $PowerBIEmbeddedName"
-                $ResumeOperation = Resume-AzureRmPowerBIEmbeddedCapacity -Name $PowerBIEmbeddedName -ResourceGroupName $AzureResourceGroup -PassThru
+                $ResumeOperation = Resume-AzPowerBIEmbeddedCapacity -Name $PowerBIEmbeddedName -ResourceGroupName $AzureResourceGroup -PassThru
                 "$PowerBIEmbeddedName Resumed Successfully "
             }
             catch


### PR DESCRIPTION
Due to changes in Azure the script is about to stop working.

The method of authentication is about  to be deprecated: Migrate from an existing Run As account to a managed identity
https://learn.microsoft.com/en-us/azure/automation/migrate-run-as-accounts-managed-identity

The used Powershell module is about to be deprecated: Migrate Azure PowerShell from AzureRM to Az
https://learn.microsoft.com/de-de/powershell/azure/migrate-from-azurerm-to-az

